### PR TITLE
Stop failed deployments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
                         <id>integration-tests</id>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/brooklyn/maven/StopApplicationMojo.java
+++ b/src/main/java/io/brooklyn/maven/StopApplicationMojo.java
@@ -18,6 +18,7 @@ package io.brooklyn.maven;
 import java.net.URL;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -52,11 +53,15 @@ public class StopApplicationMojo extends AbstractInvokeBrooklynMojo {
     }
 
     @Override
-    public void execute() throws MojoExecutionException {
+    public void execute() {
         getLog().info("Stopping application " + application);
-        String timeout = String.valueOf(getTimeout().toMilliseconds());
-        getApi().getEffectorApi().invoke(application, application, "stop", timeout,
-                ImmutableMap.<String, Object>of());
+        try {
+            String timeout = String.valueOf(getTimeout().toMilliseconds());
+            getApi().getEffectorApi().invoke(application, application, "stop", timeout,
+                    ImmutableMap.<String, Object>of());
+        } catch (Exception e) {
+            getLog().warn("Exception stopping application", e);
+        }
     }
 
 }

--- a/src/test/java/io/brooklyn/maven/QuerySensorMojoTest.java
+++ b/src/test/java/io/brooklyn/maven/QuerySensorMojoTest.java
@@ -16,7 +16,10 @@
 package io.brooklyn.maven;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -45,7 +48,7 @@ public class QuerySensorMojoTest extends AbstractBrooklynMojoTest {
         mojo.setProject(mavenProject);
         executeMojoWithTimeout(mojo);
 
-        RecordedRequest request = server.takeRequest();
+        RecordedRequest request = server.takeRequest(1, TimeUnit.MILLISECONDS);
         String expectedPath = String.format("/v1/applications/%s/entities/%s/descendants/sensor/%s?typeRegex=%s",
                 APPLICATION, APPLICATION, SENSOR, TYPE_REGEX);
         assertEquals(expectedPath, request.getPath());
@@ -59,12 +62,32 @@ public class QuerySensorMojoTest extends AbstractBrooklynMojoTest {
         server.enqueue(newJsonResponse().setBody("{}"));
         server.play();
         QuerySensorMojo mojo = new QuerySensorMojo(server.getUrl("/"), APPLICATION, SENSOR, PROJECT_PROPERTY, TYPE_REGEX);
+        mojo.setFailIfNoMatches();
         try {
             executeMojoWithTimeout(mojo);
             fail("Expected exception running query goal with no results");
         } catch (MojoFailureException e) {
-            // ignored
+            assertTrue("Expected exception message to start 'No entities' and end 'have a value for <sensor>, was: " + e.getMessage(),
+                    e.getMessage().startsWith("No entities") && e.getMessage().endsWith("have a value for " + SENSOR));
         }
+    }
+
+    @Test
+    public void testWaitsForApplicationToBeRunning() throws Exception {
+        server.enqueue(applicationStatusResponse("STARTING"));
+        server.enqueue(applicationStatusResponse("STARTING"));
+        server.enqueue(applicationStatusResponse("RUNNING"));
+        server.enqueue(newJsonResponse().setBody(Jsonya.newInstance().put(APPLICATION, "bob").toString()));
+        server.play();
+
+        MavenProject mavenProject = new BrooklynMavenProjectStub();
+        QuerySensorMojo mojo = new QuerySensorMojo(server.getUrl("/"), APPLICATION, SENSOR, PROJECT_PROPERTY, TYPE_REGEX);
+        mojo.setPollPeriod(1, TimeUnit.MILLISECONDS);
+        mojo.setProject(mavenProject);
+        mojo.setWaitForRunning();
+        executeMojoWithTimeout(mojo);
+
+        assertEquals(4, server.getRequestCount());
     }
 
 }

--- a/src/test/java/io/brooklyn/maven/StopApplicationMojoTest.java
+++ b/src/test/java/io/brooklyn/maven/StopApplicationMojoTest.java
@@ -17,6 +17,8 @@ package io.brooklyn.maven;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 
 import com.squareup.okhttp.mockwebserver.MockResponse;
@@ -34,7 +36,7 @@ public class StopApplicationMojoTest extends AbstractBrooklynMojoTest {
         StopApplicationMojo mojo = new StopApplicationMojo(server.getUrl("/"), APPLICATION);
         executeMojoWithTimeout(mojo);
 
-        RecordedRequest request = server.takeRequest();
+        RecordedRequest request = server.takeRequest(1, TimeUnit.MILLISECONDS);
         final String expectedPath = "/v1/applications/" + APPLICATION + "/entities/" + APPLICATION + "/effectors/stop" +
                 "?timeout=" + mojo.getTimeout().toMilliseconds();
         assertEquals(expectedPath, request.getPath());

--- a/src/test/java/io/brooklyn/maven/VerifyGoalsIntegrationTest.java
+++ b/src/test/java/io/brooklyn/maven/VerifyGoalsIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.it.Verifier;
 import org.apache.maven.plugin.testing.resources.TestResources;
@@ -70,7 +71,7 @@ public class VerifyGoalsIntegrationTest extends AbstractBrooklynMojoTest {
                 "server", server.getUrl("/").toString(),
                 "appId", APPLICATION));
 
-        RecordedRequest request = server.takeRequest();
+        RecordedRequest request = server.takeRequest(1, TimeUnit.MILLISECONDS);
         assertTrue(request.getPath().startsWith(String.format("/v1/applications/%s/entities/%s/descendants/sensor/",
                 APPLICATION, APPLICATION)));
         verifier.verifyErrorFreeLog();

--- a/src/test/projects/example-app/pom.xml
+++ b/src/test/projects/example-app/pom.xml
@@ -47,7 +47,6 @@
                     </execution>
                     <execution>
                         <id>Query sensor value</id>
-                        <phase>pre-integration-test</phase>
                         <goals>
                             <goal>sensor</goal>
                         </goals>

--- a/src/test/projects/test-deploy-goal/pom.xml
+++ b/src/test/projects/test-deploy-goal/pom.xml
@@ -55,6 +55,8 @@
                             <server>${server}</server>
                             <blueprint>${project.basedir}/blueprint.yaml</blueprint>
                             <propertyName>appId</propertyName>
+                            <timeout>30</timeout>
+                            <timeoutUnit>SECONDS</timeoutUnit>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/test/projects/test-teardown-on-app-failure/README
+++ b/src/test/projects/test-teardown-on-app-failure/README
@@ -1,0 +1,2 @@
+A build that will fail but whose deployment should be stopped.
+

--- a/src/test/projects/test-teardown-on-app-failure/blueprint.yaml
+++ b/src/test/projects/test-teardown-on-app-failure/blueprint.yaml
@@ -1,0 +1,6 @@
+name: Failing blueprint
+location: localhost
+services:
+- type: brooklyn.entity.webapp.tomcat.TomcatServer
+  brooklyn.config:
+    skipStart: true

--- a/src/test/projects/test-teardown-on-app-failure/pom.xml
+++ b/src/test/projects/test-teardown-on-app-failure/pom.xml
@@ -1,0 +1,58 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <name>Test of Brooklyn Maven Plugin</name>
+
+    <description>
+        Use to confirm that a failed deployment is stopped before the build exits.
+    </description>
+
+    <properties>
+        <server>http://127.0.0.1:8081</server>
+    </properties>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.brooklyn.maven</groupId>
+                <artifactId>brooklyn-maven-plugin</artifactId>
+                <version>0.1.0-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>Deploy blueprint</id>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <server>${server}</server>
+                            <blueprint>${project.basedir}/blueprint.yaml</blueprint>
+                            <propertyName>appId</propertyName>
+                            <timeoutUnit>SECONDS</timeoutUnit>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+


### PR DESCRIPTION
By default the deploy goal attempts to stop applications that are not running within the configured timeout before throwing a `MojoFailureException`.